### PR TITLE
feat(VER-2673): Create Azle image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   IMAGE_NAME_AZLE: ${{ github.repository }}-azle
 
-# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,4 +82,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             ${{ steps.meta.outputs.labels }}
-            org.opencontainers.image.description=A canister development environment for the Internet Computer (ICP) using Azle for TypeScript and JavaScript .
+            org.opencontainers.image.description=A canister development environment for the Internet Computer (ICP) using Azle for TypeScript and JavaScript.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME_AZLE: ${{ github.repository }}-azle
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
@@ -46,3 +47,39 @@ jobs:
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.description=A canister development environment for the Internet Computer (ICP).
+
+  build-and-push-image-azle:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_AZLE }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: azle
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.description=A canister development environment for the Internet Computer (ICP) using Azle for TypeScript and JavaScript .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM --platform=linux/amd64 rust:1.75-slim-bookworm
 ENV NVM_DIR=/root/.nvm
 ENV NVM_VERSION=v0.39.7
 ENV NODE_VERSION=21.5.0
-ENV DFX_VERSION=0.16.1
-ENV POCKET_IC_SERVER_HASH=69e1408347723dbaa7a6cd2faa9b65c42abbe861
-ENV POCKET_IC_PYTHON_VERSION=2.0.2
+ENV DFX_VERSION=0.17.0
+ENV POCKET_IC_SERVER_VERSION=3.0.1
+ENV POCKET_IC_PYTHON_VERSION=2.1.0
 
 RUN apt -yq update
 RUN apt -yqq install --no-install-recommends curl ca-certificates libunwind-dev git python3 python3-pip
@@ -27,6 +27,6 @@ RUN rustup target add wasm32-unknown-unknown
 RUN pip3 install pocket-ic==${POCKET_IC_PYTHON_VERSION} --break-system-packages
 
 # Download the PocketIC server
-RUN curl -sLO https://download.dfinity.systems/ic/${POCKET_IC_SERVER_HASH}/openssl-static-binaries/x86_64-linux/pocket-ic.gz
+RUN curl -Ls https://github.com/dfinity/pocketic/releases/download/${POCKET_IC_SERVER_VERSION}/pocket-ic-x86_64-linux.gz -o pocket-ic.gz
 RUN gzip -d pocket-ic.gz
 RUN chmod +x pocket-ic

--- a/README.md
+++ b/README.md
@@ -1,28 +1,31 @@
 # ICP Developer Environment
 
-This repo contains a Docker image that is used for setting up a remote, hybrid or local development environments for new developers on the IC.
+This repo contains Docker images that are used for setting up a remote, hybrid or local development environments for new developers on the Internet Computer.
 
 ## Usage
-This container image can be used as a base for creating a dev container environment that targets ICP development.
+These container images can be used as a base for creating a dev container environment that targets ICP development.
 Take a look at the repositories below to see dev containers in action:
 - [ICP Hello World Motoko](https://github.com/dfinity/icp-hello-world-motoko)
 - [ICP Hello World Rust](https://github.com/dfinity/icp-hello-world-rust)
+- [ICP Azle 201 from dacadeorg](https://github.com/dacadeorg/icp-azle-201)
+- [ICP Message Board Contract from dacadeorg](https://github.com/dacadeorg/icp-message-board-contract)
 
 ### Packages and Releases 
 On the right side, you will find new releases and the latest packages.
-You can download the Docker image with 
+You can download the Docker image for Rust/Motoko with 
 
 ```bash
 docker pull ghcr.io/dfinity/icp-dev-env:latest
 ```
 
-or 
+or the one for [Azle](https://github.com/demergent-labs/azle) (TypeScript and JavaScript) with
 
 ```bash
-docker pull ghcr.io/dfinity/icp-dev-env:<version>
+docker pull ghcr.io/dfinity/icp-dev-env-azle:latest
 ```
-for a specific version.
+
+To download a specific version, add `:<version>` at the end instead of `:latest`.
 
 ## Creating a new Release
-To release a new version, create a new tag with the corresponding version number.
+To release a new version of both images, create a new tag with the corresponding version number.
 The CI pipeline will automatically build and push the new image to the GitHub Container Registry (ghcr.io).

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ To download a specific version, add `:<version>` at the end instead of `:latest`
 
 ## Creating a new Release
 To release a new version of both images, create a new tag with the corresponding version number.
-The CI pipeline will automatically build and push the new image to the GitHub Container Registry (ghcr.io).
+The CI pipeline will automatically build and push the new images to the GitHub Container Registry (ghcr.io).

--- a/azle/Dockerfile
+++ b/azle/Dockerfile
@@ -1,0 +1,11 @@
+FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/typescript-node:dev-20-bookworm
+
+ENV DFX_VERSION=0.16.1
+
+# Install a basic environment needed for our build tools
+RUN apt -yq update && \
+    apt -yqq install --no-install-recommends curl ca-certificates \
+        build-essential pkg-config libssl-dev llvm-dev liblmdb-dev clang cmake rsync
+
+# Install dfx
+RUN sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"

--- a/azle/Dockerfile
+++ b/azle/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/typescript-node:dev-20-bookworm
 
-ENV DFX_VERSION=0.16.1
+ENV DFX_VERSION=0.17.0
 
 # Install a basic environment needed for our build tools
 RUN apt -yq update && \


### PR DESCRIPTION
- Creates an Azle docker image on a new release in addition to the rust/motoko image
- Bumps the `dfx` and PocketIC versions