### PR TITLE
chore: Bump dfx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 rust:1.75-slim-bookworm
 ENV NVM_DIR=/root/.nvm
 ENV NVM_VERSION=v0.39.7
 ENV NODE_VERSION=21.5.0
-ENV DFX_VERSION=0.17.0
+ENV DFX_VERSION=0.18.0
 ENV POCKET_IC_SERVER_VERSION=3.0.1
 ENV POCKET_IC_PYTHON_VERSION=2.1.0
 
@@ -21,6 +21,7 @@ RUN . "${NVM_DIR}/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV DFXVM_INIT_YES=true
 RUN sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
 ENV PATH="/root/.local/share/dfx/bin:$PATH"
+ENV DFX_VERSION=
 
 # Add wasm32-unknown-unknown target
 RUN rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
- bump `dfx` to 0.18.0
- unset `DFX_VERSION` after installation to make `dfxvm default ...` work