### PR TITLE
ci: use native arm64 runners and GHA layer cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Create and push multi-arch manifest
         run: |
-          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/--tag /' | tr '\n' ' ')
+          TAGS=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | grep -v '^$' | sed 's/^/--tag /' | tr '\n' ' ')
           docker buildx imagetools create $TAGS \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}@${{ needs.build-motoko-amd64.outputs.digest }} \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}@${{ needs.build-motoko-arm64.outputs.digest }}
@@ -221,7 +221,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Create and push multi-arch manifest
         run: |
-          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/--tag /' | tr '\n' ' ')
+          TAGS=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | grep -v '^$' | sed 's/^/--tag /' | tr '\n' ' ')
           docker buildx imagetools create $TAGS \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}@${{ needs.build-rust-amd64.outputs.digest }} \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}@${{ needs.build-rust-arm64.outputs.digest }}
@@ -328,7 +328,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Create and push multi-arch manifest
         run: |
-          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/--tag /' | tr '\n' ' ')
+          TAGS=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | grep -v '^$' | sed 's/^/--tag /' | tr '\n' ' ')
           docker buildx imagetools create $TAGS \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}@${{ needs.build-all-amd64.outputs.digest }} \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}@${{ needs.build-all-arm64.outputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -57,7 +56,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -129,7 +127,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -166,7 +163,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -238,7 +234,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -275,7 +270,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -56,6 +57,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -127,6 +129,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -163,6 +166,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -234,6 +238,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -270,6 +275,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
   # ── motoko ──────────────────────────────────────────────────────────────────
   build-motoko-amd64:
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -34,13 +36,13 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build and push linux/amd64
+      - name: Build and push linux/amd64 by digest
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           platforms: linux/amd64
           context: motoko
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}:${{ github.sha }}-amd64
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }},push-by-digest=true,name-canonical=true,push=true
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.description=A Motoko canister development environment for the Internet Computer (ICP) with icp-cli, moc, and mops.
@@ -49,6 +51,8 @@ jobs:
 
   build-motoko-arm64:
     runs-on: ubuntu-24.04-arm
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -68,13 +72,13 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build and push linux/arm64
+      - name: Build and push linux/arm64 by digest
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           platforms: linux/arm64
           context: motoko
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}:${{ github.sha }}-arm64
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }},push-by-digest=true,name-canonical=true,push=true
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.description=A Motoko canister development environment for the Internet Computer (ICP) with icp-cli, moc, and mops.
@@ -104,6 +108,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=ref,event=branch
+            type=ref,event=tag
             type=semver,pattern={{version}}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -111,12 +116,14 @@ jobs:
         run: |
           TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/--tag /' | tr '\n' ' ')
           docker buildx imagetools create $TAGS \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}:${{ github.sha }}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}:${{ github.sha }}-arm64
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}@${{ needs.build-motoko-amd64.outputs.digest }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}@${{ needs.build-motoko-arm64.outputs.digest }}
 
   # ── rust ────────────────────────────────────────────────────────────────────
   build-rust-amd64:
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -136,13 +143,13 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build and push linux/amd64
+      - name: Build and push linux/amd64 by digest
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           platforms: linux/amd64
           context: rust
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}:${{ github.sha }}-amd64
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }},push-by-digest=true,name-canonical=true,push=true
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.description=A Rust canister development environment for the Internet Computer (ICP) with icp-cli and Rust toolchain.
@@ -151,6 +158,8 @@ jobs:
 
   build-rust-arm64:
     runs-on: ubuntu-24.04-arm
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -170,13 +179,13 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build and push linux/arm64
+      - name: Build and push linux/arm64 by digest
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           platforms: linux/arm64
           context: rust
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}:${{ github.sha }}-arm64
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }},push-by-digest=true,name-canonical=true,push=true
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.description=A Rust canister development environment for the Internet Computer (ICP) with icp-cli and Rust toolchain.
@@ -206,6 +215,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=ref,event=branch
+            type=ref,event=tag
             type=semver,pattern={{version}}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -213,12 +223,14 @@ jobs:
         run: |
           TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/--tag /' | tr '\n' ' ')
           docker buildx imagetools create $TAGS \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}:${{ github.sha }}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}:${{ github.sha }}-arm64
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}@${{ needs.build-rust-amd64.outputs.digest }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}@${{ needs.build-rust-arm64.outputs.digest }}
 
   # ── all ─────────────────────────────────────────────────────────────────────
   build-all-amd64:
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -238,13 +250,13 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build and push linux/amd64
+      - name: Build and push linux/amd64 by digest
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           platforms: linux/amd64
           context: all
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}:${{ github.sha }}-amd64
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }},push-by-digest=true,name-canonical=true,push=true
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.description=A combined Motoko and Rust canister development environment for the Internet Computer (ICP) with icp-cli, Rust toolchain, and mops.
@@ -253,6 +265,8 @@ jobs:
 
   build-all-arm64:
     runs-on: ubuntu-24.04-arm
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -272,13 +286,13 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build and push linux/arm64
+      - name: Build and push linux/arm64 by digest
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           platforms: linux/arm64
           context: all
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}:${{ github.sha }}-arm64
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }},push-by-digest=true,name-canonical=true,push=true
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.description=A combined Motoko and Rust canister development environment for the Internet Computer (ICP) with icp-cli, Rust toolchain, and mops.
@@ -308,6 +322,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=ref,event=branch
+            type=ref,event=tag
             type=semver,pattern={{version}}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -315,5 +330,5 @@ jobs:
         run: |
           TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/--tag /' | tr '\n' ' ')
           docker buildx imagetools create $TAGS \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}:${{ github.sha }}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}:${{ github.sha }}-arm64
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}@${{ needs.build-all-amd64.outputs.digest }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}@${{ needs.build-all-arm64.outputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Create and push multi-arch manifest
         run: |
-          TAGS=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | grep -v '^$' | sed 's/^/--tag /' | tr '\n' ' ')
+          TAGS=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | awk NF | sed 's/^/--tag /' | tr '\n' ' ')
           docker buildx imagetools create $TAGS \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}@${{ needs.build-motoko-amd64.outputs.digest }} \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}@${{ needs.build-motoko-arm64.outputs.digest }}
@@ -221,7 +221,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Create and push multi-arch manifest
         run: |
-          TAGS=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | grep -v '^$' | sed 's/^/--tag /' | tr '\n' ' ')
+          TAGS=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | awk NF | sed 's/^/--tag /' | tr '\n' ' ')
           docker buildx imagetools create $TAGS \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}@${{ needs.build-rust-amd64.outputs.digest }} \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}@${{ needs.build-rust-arm64.outputs.digest }}
@@ -328,7 +328,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Create and push multi-arch manifest
         run: |
-          TAGS=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | grep -v '^$' | sed 's/^/--tag /' | tr '\n' ' ')
+          TAGS=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | awk NF | sed 's/^/--tag /' | tr '\n' ' ')
           docker buildx imagetools create $TAGS \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}@${{ needs.build-all-amd64.outputs.digest }} \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}@${{ needs.build-all-arm64.outputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ env:
   IMAGE_NAME_ALL: ${{ github.repository }}-all
 
 jobs:
-  build-and-push-image-motoko:
+  # ── motoko ──────────────────────────────────────────────────────────────────
+  build-motoko-amd64:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,7 +27,76 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (labels)
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Build and push linux/amd64
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          platforms: linux/amd64
+          context: motoko
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}:${{ github.sha }}-amd64
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.description=A Motoko canister development environment for the Internet Computer (ICP) with icp-cli, moc, and mops.
+          cache-from: type=gha,scope=motoko-amd64
+          cache-to: type=gha,mode=max,scope=motoko-amd64
+
+  build-motoko-arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (labels)
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Build and push linux/arm64
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          platforms: linux/arm64
+          context: motoko
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}:${{ github.sha }}-arm64
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.description=A Motoko canister development environment for the Internet Computer (ICP) with icp-cli, moc, and mops.
+          cache-from: type=gha,scope=motoko-arm64
+          cache-to: type=gha,mode=max,scope=motoko-arm64
+
+  merge-motoko:
+    needs: [build-motoko-amd64, build-motoko-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags)
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
@@ -35,22 +105,17 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=ref,event=branch
             type=semver,pattern={{version}}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build and push Docker image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: motoko
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: |
-            ${{ steps.meta.outputs.labels }}
-            org.opencontainers.image.description=A Motoko canister development environment for the Internet Computer (ICP) with icp-cli, moc, and mops.
+      - name: Create and push multi-arch manifest
+        run: |
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/--tag /' | tr '\n' ' ')
+          docker buildx imagetools create $TAGS \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_MOTOKO }}:${{ github.sha }}-arm64
 
-  build-and-push-image-rust:
+  # ── rust ────────────────────────────────────────────────────────────────────
+  build-rust-amd64:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,7 +129,76 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (labels)
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Build and push linux/amd64
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          platforms: linux/amd64
+          context: rust
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}:${{ github.sha }}-amd64
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.description=A Rust canister development environment for the Internet Computer (ICP) with icp-cli and Rust toolchain.
+          cache-from: type=gha,scope=rust-amd64
+          cache-to: type=gha,mode=max,scope=rust-amd64
+
+  build-rust-arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (labels)
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Build and push linux/arm64
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          platforms: linux/arm64
+          context: rust
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}:${{ github.sha }}-arm64
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.description=A Rust canister development environment for the Internet Computer (ICP) with icp-cli and Rust toolchain.
+          cache-from: type=gha,scope=rust-arm64
+          cache-to: type=gha,mode=max,scope=rust-arm64
+
+  merge-rust:
+    needs: [build-rust-amd64, build-rust-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags)
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
@@ -73,22 +207,17 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=ref,event=branch
             type=semver,pattern={{version}}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build and push Docker image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: rust
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: |
-            ${{ steps.meta.outputs.labels }}
-            org.opencontainers.image.description=A Rust canister development environment for the Internet Computer (ICP) with icp-cli and Rust toolchain.
+      - name: Create and push multi-arch manifest
+        run: |
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/--tag /' | tr '\n' ' ')
+          docker buildx imagetools create $TAGS \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_RUST }}:${{ github.sha }}-arm64
 
-  build-and-push-image-all:
+  # ── all ─────────────────────────────────────────────────────────────────────
+  build-all-amd64:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -102,7 +231,76 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (labels)
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Build and push linux/amd64
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          platforms: linux/amd64
+          context: all
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}:${{ github.sha }}-amd64
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.description=A combined Motoko and Rust canister development environment for the Internet Computer (ICP) with icp-cli, Rust toolchain, and mops.
+          cache-from: type=gha,scope=all-amd64
+          cache-to: type=gha,mode=max,scope=all-amd64
+
+  build-all-arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (labels)
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Build and push linux/arm64
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          platforms: linux/arm64
+          context: all
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}:${{ github.sha }}-arm64
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.description=A combined Motoko and Rust canister development environment for the Internet Computer (ICP) with icp-cli, Rust toolchain, and mops.
+          cache-from: type=gha,scope=all-arm64
+          cache-to: type=gha,mode=max,scope=all-arm64
+
+  merge-all:
+    needs: [build-all-amd64, build-all-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags)
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
@@ -111,17 +309,11 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=ref,event=branch
             type=semver,pattern={{version}}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build and push Docker image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: all
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: |
-            ${{ steps.meta.outputs.labels }}
-            org.opencontainers.image.description=A combined Motoko and Rust canister development environment for the Internet Computer (ICP) with icp-cli, Rust toolchain, and mops.
+      - name: Create and push multi-arch manifest
+        run: |
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/--tag /' | tr '\n' ' ')
+          docker buildx imagetools create $TAGS \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_ALL }}:${{ github.sha }}-arm64


### PR DESCRIPTION
## Problem

All three images were built using QEMU to emulate `linux/arm64` on an amd64 runner. Rust compilation under QEMU is ~10–20× slower than native, which caused the `rust` and `all` image builds to take ~50 minutes.

## Changes

**Native arm64 runners** — each image build is split into two parallel jobs:
- `build-{name}-amd64` on `ubuntu-latest` (native amd64)
- `build-{name}-arm64` on `ubuntu-24.04-arm` (native arm64, free for public repos)

A third `merge-{name}` job waits for both, then assembles the final multi-arch manifest via `docker buildx imagetools create`. The published result is identical to before: a single multi-arch image tag covering both platforms.

**Push by digest** — platform builds use `push-by-digest=true` and pass their digest as a job output. The merge job references images by digest (`{image}@sha256:...`) rather than SHA-suffixed tags, so no intermediate tags accumulate in GHCR.

**GHA layer cache** — `cache-from`/`cache-to: type=gha,mode=max` is added to every platform build, scoped per image and platform (e.g. `scope=rust-arm64`). When only `ICP_CLI_VERSION` changes, the slow `cargo binstall candid-extractor` layer is served from cache and skipped entirely. No `actions: write` permission is needed — the `type=gha` cache backend uses `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN`.

**Tag ref support** — added `type=ref,event=tag` to all merge jobs so `workflow_dispatch` triggered on a tag ref always produces at least one `--tag` destination for `imagetools create`.

**Safe TAGS construction** — the merge steps use `printf` + `grep -v '^$'` to filter blank lines before building the `--tag` argument list, preventing a bare `--tag ` with no value if the tags output were ever empty.

QEMU setup is removed from all jobs — it's no longer needed.

## Expected impact

| Scenario | Before | After (est.) |
|---|---|---|
| Cold build, rust/all arm64 | ~45 min (QEMU) | ~5–8 min (native) |
| Warm build (icp-cli bump only) | ~45 min (QEMU, no cache) | ~2–3 min (cache hit on cargo layer) |
| Cold build, motoko | ~5 min | ~3 min |

## Test plan

- [ ] Trigger `workflow_dispatch` on this branch and verify all 9 jobs succeed
- [ ] Verify GHCR shows both `linux/amd64` and `linux/arm64` in the manifest for each image
- [ ] Confirm build times are significantly reduced for the `rust` and `all` arm64 jobs
- [ ] Confirm no intermediate tags appear in GHCR after the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)