### PR TITLE
feat: add yq to all images

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For Motoko canister development.
 | [ic-wasm](https://github.com/dfinity/ic-wasm) | 0.9.11 |
 | [mops](https://mops.one) | 2.13.2 |
 | moc | installed per-project via `mops install` |
+| [yq](https://github.com/mikefarah/yq) | 4.53.3 |
 | Node.js | 24.15.0 |
 | pnpm | 11.4.0 |
 
@@ -31,6 +32,7 @@ For Rust canister development.
 | [icp-cli](https://cli.internetcomputer.org) | 0.3.2 |
 | [ic-wasm](https://github.com/dfinity/ic-wasm) | 0.9.11 |
 | [candid-extractor](https://github.com/dfinity/cdk-rs) | 0.1.4 |
+| [yq](https://github.com/mikefarah/yq) | 4.53.3 |
 | Rust | 1.95.0 |
 | wasm32-unknown-unknown target | — |
 | Node.js | 24.15.0 |
@@ -52,6 +54,7 @@ Combined Motoko and Rust development environment. Use this when your project inc
 | [candid-extractor](https://github.com/dfinity/cdk-rs) | 0.1.4 |
 | [mops](https://mops.one) | 2.13.2 |
 | moc | installed per-project via `mops install` |
+| [yq](https://github.com/mikefarah/yq) | 4.53.3 |
 | Rust | 1.95.0 |
 | wasm32-unknown-unknown target | — |
 | Node.js | 24.15.0 |

--- a/all/Dockerfile
+++ b/all/Dockerfile
@@ -7,6 +7,9 @@ ARG ICP_CLI_VERSION=0.3.2
 ARG IC_WASM_VERSION=0.9.11
 ARG CANDID_EXTRACTOR_VERSION=0.1.4
 ARG IC_MOPS_VERSION=2.13.2
+ARG YQ_VERSION=4.53.3
+ARG YQ_SHA256_AMD64=fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
+ARG YQ_SHA256_ARM64=578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea
 
 ENV NVM_DIR=/root/.nvm
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin:${PATH}"
@@ -14,6 +17,18 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin:${PATH}"
 RUN apt-get -yq update && apt-get -yq upgrade && apt-get -yqq install --no-install-recommends \
     curl ca-certificates git jq make libdbus-1-3 && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# yq (YAML processor, mikefarah/yq)
+RUN ARCH=$(dpkg --print-architecture) && \
+    case "${ARCH}" in \
+      amd64) YQ_SHA256=${YQ_SHA256_AMD64} ;; \
+      arm64) YQ_SHA256=${YQ_SHA256_ARM64} ;; \
+      *) echo "unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac && \
+    curl --fail -sSL -o /usr/local/bin/yq \
+    https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${ARCH} && \
+    echo "${YQ_SHA256}  /usr/local/bin/yq" | sha256sum -c - && \
+    chmod +x /usr/local/bin/yq
 
 # Node.js via nvm (required for icp-cli, ic-wasm, mops)
 RUN curl --fail -sSf https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash && \

--- a/motoko/Dockerfile
+++ b/motoko/Dockerfile
@@ -6,6 +6,9 @@ ARG PNPM_VERSION=11.4.0
 ARG ICP_CLI_VERSION=0.3.2
 ARG IC_WASM_VERSION=0.9.11
 ARG IC_MOPS_VERSION=2.13.2
+ARG YQ_VERSION=4.53.3
+ARG YQ_SHA256_AMD64=fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
+ARG YQ_SHA256_ARM64=578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea
 
 ENV NVM_DIR=/root/.nvm
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin:${PATH}"
@@ -13,6 +16,18 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin:${PATH}"
 RUN apt-get -yq update && apt-get -yq upgrade && apt-get -yqq install --no-install-recommends \
     curl ca-certificates git jq make libdbus-1-3 && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# yq (YAML processor, mikefarah/yq)
+RUN ARCH=$(dpkg --print-architecture) && \
+    case "${ARCH}" in \
+      amd64) YQ_SHA256=${YQ_SHA256_AMD64} ;; \
+      arm64) YQ_SHA256=${YQ_SHA256_ARM64} ;; \
+      *) echo "unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac && \
+    curl --fail -sSL -o /usr/local/bin/yq \
+    https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${ARCH} && \
+    echo "${YQ_SHA256}  /usr/local/bin/yq" | sha256sum -c - && \
+    chmod +x /usr/local/bin/yq
 
 # Node.js via nvm (required for icp-cli, ic-wasm, mops)
 RUN curl --fail -sSf https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash && \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -6,6 +6,9 @@ ARG PNPM_VERSION=11.4.0
 ARG ICP_CLI_VERSION=0.3.2
 ARG IC_WASM_VERSION=0.9.11
 ARG CANDID_EXTRACTOR_VERSION=0.1.4
+ARG YQ_VERSION=4.53.3
+ARG YQ_SHA256_AMD64=fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
+ARG YQ_SHA256_ARM64=578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea
 
 ENV NVM_DIR=/root/.nvm
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin:${PATH}"
@@ -13,6 +16,18 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin:${PATH}"
 RUN apt-get -yq update && apt-get -yq upgrade && apt-get -yqq install --no-install-recommends \
     curl ca-certificates git jq make libdbus-1-3 && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# yq (YAML processor, mikefarah/yq)
+RUN ARCH=$(dpkg --print-architecture) && \
+    case "${ARCH}" in \
+      amd64) YQ_SHA256=${YQ_SHA256_AMD64} ;; \
+      arm64) YQ_SHA256=${YQ_SHA256_ARM64} ;; \
+      *) echo "unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac && \
+    curl --fail -sSL -o /usr/local/bin/yq \
+    https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${ARCH} && \
+    echo "${YQ_SHA256}  /usr/local/bin/yq" | sha256sum -c - && \
+    chmod +x /usr/local/bin/yq
 
 # Node.js via nvm (required for icp-cli and ic-wasm)
 RUN curl --fail -sSf https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash && \


### PR DESCRIPTION
## Summary

- Adds [mikefarah/yq](https://github.com/mikefarah/yq) 4.53.3 to the `motoko`, `rust`, and `all` images, pinned via `ARG` like the other tools
- Installed as a static binary from GitHub releases, with the architecture resolved via `dpkg --print-architecture` so both `linux/amd64` and `linux/arm64` builds work
- The downloaded binary is verified against per-arch sha256 checksums (cross-checked against the `checksums` file published with the upstream release); the build fails on mismatch or unknown architecture
- Adds yq to the tool tables in the README

The Go-based mikefarah/yq is used rather than Debian's apt `yq` package, since the apt version is a Python jq-wrapper with incompatible syntax and can't be version-pinned.

## Testing

- Built `motoko/Dockerfile` locally: checksum step reports `/usr/local/bin/yq: OK`, `yq --version` reports v4.53.3, and a YAML query returns the expected value
- Verified both release assets exist and their checksums match the official `checksums` file for v4.53.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)